### PR TITLE
handles long partiton names and jobs using the --array feature

### DIFF
--- a/sfree
+++ b/sfree
@@ -18,7 +18,7 @@ def run(command):
 def get_queues(lines):
     queues = []
     for line in lines[:-1]:
-        queues.append(line[3])
+        queues.append(line[0])
     return queues
 
 def parse_snodes(snodes):
@@ -149,7 +149,7 @@ def get_job_info(node_name):
 
         job_output = run("scontrol show jobid -d " + job_id)
 
-        job_name = job_output[0][1].split("=")[1]
+        job_name = job_output[0][-1].split("=")[1]
         num_nodes = int(job_output[14][0].split("=")[1])
         num_cpus = int(job_output[14][1].split("=")[1])
         mem = int(job_output[16][2].split("=")[1])
@@ -190,7 +190,7 @@ def get_memory_info(node_list):
 
 
 # Get the partitions the user have access to.
-command = "sacctmgr show associations -n user=$USER"
+command = "sacctmgr show associations format=Partition%15 -n user=$USER"
 
 # Only get partitions from the user given account
 account = None


### PR DESCRIPTION
Example partition name 'kemi_gemma'
example job_id screwing with the old parser 1848518_434
